### PR TITLE
Fix pico_editor when Pico installed within non-empty base_url

### DIFF
--- a/pico_editor.php
+++ b/pico_editor.php
@@ -63,6 +63,7 @@ class Pico_Editor {
 				if(isset($_POST['password'])){
 					if(sha1($_POST['password']) == $this->password){
 						$_SESSION['pico_logged_in'] = true;
+						$_SESSION['pico_config'] = $twig_vars['config'];
 					} else {
 						$twig_vars['login_error'] = 'Invalid password.';
 						echo $twig_editor->render('login.html', $twig_vars); // Render login.html
@@ -78,7 +79,27 @@ class Pico_Editor {
 			exit; // Don't continue to render template
 		}
 	}
-	
+
+	/**
+	 * Returns real file name to be edited.
+	 *
+	 * @param string $file_url the file URL to be edited
+	 * @return string
+	 */
+	private static function get_real_filename($file_url) {
+
+		$file_components = parse_url($file_url); // inner
+		$base_components = parse_url($_SESSION['pico_config']['base_url']);
+		$file_path = rtrim($file_components['path'], '/');
+		$base_path = rtrim($base_components['path'], '/');
+
+		if (empty($file_path) || $file_path === $base_path) {
+			return 'index';
+		} else {
+			return basename(strip_tags($file_path));
+		}
+	}
+
 	private function do_new()
 	{
 		if(!isset($_SESSION['pico_logged_in']) || !$_SESSION['pico_logged_in']) die(json_encode(array('error' => 'Error: Unathorized')));
@@ -111,7 +132,7 @@ Date: '. date('Y/m/d') .'
 	{
 		if(!isset($_SESSION['pico_logged_in']) || !$_SESSION['pico_logged_in']) die(json_encode(array('error' => 'Error: Unathorized')));
 		$file_url = isset($_POST['file']) && $_POST['file'] ? $_POST['file'] : '';
-		$file = basename(strip_tags($file_url));
+		$file = self::get_real_filename($file_url);
 		if(!$file) die('Error: Invalid file');
 		
 		$file .= CONTENT_EXT;
@@ -123,7 +144,7 @@ Date: '. date('Y/m/d') .'
 	{
 		if(!isset($_SESSION['pico_logged_in']) || !$_SESSION['pico_logged_in']) die(json_encode(array('error' => 'Error: Unathorized')));
 		$file_url = isset($_POST['file']) && $_POST['file'] ? $_POST['file'] : '';
-		$file = basename(strip_tags($file_url));
+		$file = self::get_real_filename($file_url);
 		if(!$file) die('Error: Invalid file');
 		$content = isset($_POST['content']) && $_POST['content'] ? $_POST['content'] : '';
 		if(!$content) die('Error: Invalid content');
@@ -137,7 +158,7 @@ Date: '. date('Y/m/d') .'
 	{
 		if(!isset($_SESSION['pico_logged_in']) || !$_SESSION['pico_logged_in']) die(json_encode(array('error' => 'Error: Unathorized')));
 		$file_url = isset($_POST['file']) && $_POST['file'] ? $_POST['file'] : '';
-		$file = basename(strip_tags($file_url));
+		$file = self::get_real_filename($file_url);
 		if(!$file) die('Error: Invalid file');
 		
 		$file .= CONTENT_EXT;


### PR DESCRIPTION
Hi,

First of all, thank you for awesome and very simple CMS as well as for a bunch of ready-to-use plugins.

I'm completely new in Pico, just started playing with it, but found an issue in _pico_editor_ when Pico has not been installed in the default, i.e. empty base URL.

My configuration is the following:

``` php
$config = array(
    'site_title'     => 'Pico',
    'base_url'       => 'http://localhost/pico',
    'theme'          => 'default',
    'date_format'    => 'jS M Y',
    'twig_config'    => array('cache' => false, 'autoescape' => false, 'debug' => false),
    'pages_order_by' => 'alpha',
    'pages_order'    => 'asc',
    'excerpt_length' => 50
);
```

As you can see I do have Pico installed in sub directory called `pico`. It works fine, but _pico_editor_ is having troubles whenever I'm trying to edit index.md file (it does not recognize it, even when default base URL is used).

The attached commit fix described problem with empty and non-empty base URL.

Tested on top of https://github.com/gilbitron/Pico/commit/45cd4ca5b7c35399f65065341a9676c629399a62

Works fine with any combination of base URL, but I tested this fix with the following configurations:

``` plain
http://localhost
http://localhost/pico
http://localhost/services/pico
```
